### PR TITLE
Allow empty cells.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ The following are a description of the example entries
   * ``Example (Test Expression)``: An example that shows how to initially only display columns that contain ``CHISQ`` or ``PF6``.
   * ``Example (Display All)``: Simple example that shows the entire dataset.
 
+## Empty cells in CSV file
+
+If there is a row in your CSV file that should not have a value, you may either insert a "NaN" into that column or leave it blank.
+For example, either should work
+```
+x0,x1,x2,x3
+10,20,30,40
+10,20,NaN,40
+10,20,,40
+```
+
 ## Parameter names with special characters
 
 Cinema:Debye-Scherrer uses regular expressions to sort parameters.

--- a/cinema-components/src/Database.js
+++ b/cinema-components/src/Database.js
@@ -79,11 +79,14 @@
 
 			//Get dimensions (First row of data)
 			self.dimensions = data_arr[0];
-			
 			//Convert rows from arrays to objects
 			self.data = data_arr.slice(1).map(function(d) {
+				console.log("AA", d);
 				var obj = {};
-				self.dimensions.forEach(function(p,i){obj[p] = d[i].trim();});
+				self.dimensions.forEach(function(p,i){
+                                    if (d[i] != undefined)
+                                        obj[p] = d[i].trim();
+                                });
 				return obj;
 			});
 


### PR DESCRIPTION
Feedback from Sven Vogel:
  * Allow empty columns in addition to columns with ``NaN``. These both get treated as "NaN".
  * Add to ``README.md`` a bit saying you should use ``NaN`` or leave it blank for undefined columns.