### PR TITLE
Highlight the displayLabel in image spread to link with parallel coorindates plot

### DIFF
--- a/cinema-components/src/ImageSpread.js
+++ b/cinema-components/src/ImageSpread.js
@@ -211,6 +211,26 @@
 	CINEMA_COMPONENTS.ImageSpread.prototype = Object.create(CINEMA_COMPONENTS.Component.prototype);
 	CINEMA_COMPONENTS.ImageSpread.prototype.constructor = CINEMA_COMPONENTS.ImageSpread;
 
+        /**
+         * Set the chart's current highlighted data to the data represented
+         * by the given list of indices
+         */
+        CINEMA_COMPONENTS.ImageSpread.prototype.setHighlightedPoints = function(indices) {
+                this.highlighted = indices;
+                this.redrawHighlightedPoints();
+        }
+
+        /**
+         * Redraw the current selection of points
+         */
+        CINEMA_COMPONENTS.ImageSpread.prototype.redrawHighlightedPoints = function() {
+            var self = this;
+            d3.selectAll(".displayLabel").attr("style", "");
+            this.highlighted.forEach(function(d) {
+                d3.select(".displayLabel[index='" + d + "']").attr("style", "color:red");
+                });
+            };
+
 	/**
 	 * Should be called every time the size of the component's container changes.
 	 * Updates the sizing of the imageSpread container
@@ -303,6 +323,7 @@
 						//Create content of each file display
 						.each(function(f,i) {
 							d3.select(this).select('.display').html('');
+                                                        d3.select(this).select('.displayLabel').attr('index', d);
 							//Create an image in the display if the it is an image filetype
 							if (isValidFiletype(getFileExtension(f)))
 								d3.select(this).select('.display')

--- a/js/main.js
+++ b/js/main.js
@@ -490,12 +490,12 @@ function updateViewContainerSize() {
 function handleMouseover(index, event) {
     if (index != null) {
         pcoord.setHighlightedPaths([index]);
-        if (currentView == viewType.SCATTERPLOT || currentView == viewType.TABLE)
+        if (currentView == viewType.IMAGESPREAD || currentView == viewType.SCATTERPLOT || currentView == viewType.TABLE)
             view.setHighlightedPoints([index]);
     }
     else {
         pcoord.setHighlightedPaths([]);
-        if (currentView == viewType.SCATTERPLOT || currentView == viewType.TABLE)
+        if (currentView == viewType.IMAGESPREAD || currentView == viewType.SCATTERPLOT || currentView == viewType.TABLE)
             view.setHighlightedPoints([]);
 }
     if (currentView != viewType.TABLE)


### PR DESCRIPTION
Right now when you hover over parallel coordinates plot nothing highlights which image in image spread corresponds to that line. This highlights the image label.